### PR TITLE
fix: domain attribute

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -42,7 +42,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
     const scriptProps = {
       async: true,
       defer: true,
-      domain: domain,
+      'data-domain': domain,
       src: proxyScript || `https://${plausibleDomain}${scriptURI}`,
     };
     if (trackAcquisition) {


### PR DESCRIPTION
plausible requires the attribute to be `data-domain`, not just `domain`.

Hey 👋 ,

I discovered this today when the plausible team pointed out that my site doesn't use the data-domain attribute, so I thought I'd commit this fix upstream